### PR TITLE
機能追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'package:onemin_front/models/schedule.dart'; // 追加：Scheduleモデ�
 
 // 既存のインポート
 import 'package:onemin_front/pages/show_history.dart';
-import 'package:onemin_front/pages/show_history.dart'; //追加：show_historyへのパス
 import 'package:onemin_front/pages/schedule_creation_screen.dart';
 import 'package:onemin_front/pages/measurement_start_screen.dart';
 import 'package:onemin_front/pages/notification_timer_page.dart';
@@ -25,21 +24,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
@@ -49,16 +33,6 @@ class MyApp extends StatelessWidget {
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
   final String title;
 
   @override
@@ -69,33 +43,32 @@ class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
 
   // ==========================================
-  // 【追加】スタート画面用の状態変数
+  // スタート画面用の状態変数
   // ==========================================
   late Timer _clockTimer;
   DateTime _currentTime = DateTime.now().toUtc().add(const Duration(hours: 9)); // 東京時間に設定
   List<Schedule> _schedules = [];
-  Schedule? _selectedSchedule;
+  
+  // 変更：Scheduleオブジェクトの代わりに「タイトル(文字列)」で選択状態を管理します
+  String? _selectedTitle; 
 
   @override
   void initState() {
     super.initState();
-    // 1. 時計を1秒ごとに更新するタイマー
     _clockTimer = Timer.periodic(const Duration(seconds: 1), (_) {
       setState(() {
         _currentTime = DateTime.now().toUtc().add(const Duration(hours: 9));
       });
     });
-    // 2. アプリ起動時に保存されたスケジュールを読み込む
     _loadSchedules();
   }
 
   @override
   void dispose() {
-    _clockTimer.cancel(); // 画面を破棄するときにタイマーを止める
+    _clockTimer.cancel();
     super.dispose();
   }
 
-  // 【追加】ローカルからスケジュールを読み込む処理
   Future<void> _loadSchedules() async {
     final prefs = await SharedPreferences.getInstance();
     final stored = prefs.getStringList('schedules') ?? [];
@@ -106,18 +79,14 @@ class _MyHomePageState extends State<MyHomePage> {
 
     setState(() {
       _schedules = schedules;
-      // 再読み込み時、選択されていたスケジュールがまだ存在するか確認する
-      if (_selectedSchedule != null) {
-        try {
-          _selectedSchedule = _schedules.firstWhere((s) => s.title == _selectedSchedule!.title);
-        } catch (e) {
-          _selectedSchedule = null;
-        }
+      // 選択されていた予定が削除されるなどして無くなった場合はリセット
+      if (_selectedTitle != null && _selectedTitle != "__NO_SCHEDULE__") {
+        final exists = _schedules.any((s) => s.title == _selectedTitle);
+        if (!exists) _selectedTitle = null;
       }
     });
   }
 
-  // 【追加】計測結果をローカルに保存する処理
   Future<void> _saveSchedules(List<Schedule> schedules) async {
     final prefs = await SharedPreferences.getInstance();
     final encoded = schedules
@@ -128,35 +97,53 @@ class _MyHomePageState extends State<MyHomePage> {
 
   void _incrementCounter() {
     setState(() {
-
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
       _counter++;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // 時間表示用の文字列 (例: 17:20)
     final timeString = "${_currentTime.hour.toString().padLeft(2, '0')}:${_currentTime.minute.toString().padLeft(2, '0')}";
+
+    // 現在選択されている具体的なスケジュールオブジェクトを取得（目標時間表示用）
+    Schedule? currentSchedule;
+    if (_selectedTitle != null && _selectedTitle != "__NO_SCHEDULE__" && _selectedTitle != "__CREATE_NEW__") {
+      try {
+        currentSchedule = _schedules.firstWhere((s) => s.title == _selectedTitle);
+      } catch (e) {
+        currentSchedule = null;
+      }
+    }
+
+    // プルダウンの選択肢を作成
+    List<DropdownMenuItem<String>> dropdownItems = [
+      const DropdownMenuItem(
+        value: "__CREATE_NEW__", 
+        child: Text("＋ 新規予定作成", style: TextStyle(fontSize: 18, color: Colors.blue, fontWeight: FontWeight.bold))
+      ),
+      const DropdownMenuItem(
+        value: "__NO_SCHEDULE__", 
+        child: Text("予定を選択せず開始", style: TextStyle(fontSize: 18, color: Colors.green))
+      ),
+    ];
+    // 保存されているスケジュールを追加
+    dropdownItems.addAll(_schedules.map((Schedule schedule) {
+      return DropdownMenuItem<String>(
+        value: schedule.title,
+        child: Text(schedule.title, style: const TextStyle(fontSize: 18)),
+      );
+    }));
 
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: Text(widget.title),
       ),
-      // 【重要】既存要素を消さずにエラーを防ぐため、SingleChildScrollViewで画面全体をスクロール可能にしました
       body: SingleChildScrollView(
         child: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              // ==========================================
-              // 【追加】アプリ開始画面のUI (添付画像を再現)
-              // ==========================================
               const SizedBox(height: 30),
               
               // 1. 現在時刻の表示
@@ -183,19 +170,36 @@ class _MyHomePageState extends State<MyHomePage> {
               const SizedBox(height: 10),
 
               // 2. 予定のプルダウン選択
-              DropdownButton<Schedule>(
+              DropdownButton<String>(
                 hint: const Text('予定を選択してください', style: TextStyle(fontSize: 18)),
-                value: _selectedSchedule,
-                items: _schedules.map((Schedule schedule) {
-                  return DropdownMenuItem<Schedule>(
-                    value: schedule,
-                    child: Text(schedule.title, style: const TextStyle(fontSize: 18)),
-                  );
-                }).toList(),
-                onChanged: (Schedule? newValue) {
-                  setState(() {
-                    _selectedSchedule = newValue;
-                  });
+                // __CREATE_NEW__の時は表示をリセット（遷移だけするため）
+                value: _selectedTitle == "__CREATE_NEW__" ? null : _selectedTitle,
+                items: dropdownItems,
+                onChanged: (String? newValue) async {
+                  if (newValue == "__CREATE_NEW__") {
+                    // 「新規予定作成」が選ばれたら作成画面へ
+                    final result = await Navigator.push<Map<String, dynamic>>(
+                      context,
+                      MaterialPageRoute(builder: (context) => const ScheduleCreationScreen()),
+                    );
+                    // 作成して戻ってきたら、その予定をリストに追加して選択状態にする
+                    if (result != null) {
+                      final newSchedule = Schedule(
+                        title: result['title'] as String,
+                        duration: result['duration'] as Duration,
+                      );
+                      setState(() {
+                        _schedules = [..._schedules, newSchedule];
+                        _selectedTitle = newSchedule.title; // 作った予定を選択
+                      });
+                      await _saveSchedules(_schedules);
+                    }
+                  } else {
+                    // それ以外の場合は普通に選択状態を更新
+                    setState(() {
+                      _selectedTitle = newValue;
+                    });
+                  }
                 },
               ),
               const SizedBox(height: 30),
@@ -203,34 +207,44 @@ class _MyHomePageState extends State<MyHomePage> {
               // 3. 目標時間の表示
               const Text('目標時間', style: TextStyle(fontSize: 24)),
               Text(
-                _selectedSchedule != null
-                    ? "${_selectedSchedule!.duration.inHours.toString().padLeft(2, '0')}:${(_selectedSchedule!.duration.inMinutes % 60).toString().padLeft(2, '0')}"
-                    : "--:--",
+                currentSchedule != null
+                    ? "${currentSchedule.duration.inHours.toString().padLeft(2, '0')}:${(currentSchedule.duration.inMinutes % 60).toString().padLeft(2, '0')}"
+                    : (_selectedTitle == "__NO_SCHEDULE__" ? "00:00" : "--:--"), // 予定なしの場合は00:00
                 style: const TextStyle(fontSize: 50, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 30),
 
-              // 4. スタートボタン (予定選択時のみ押せる)
+              // 4. スタートボタン
               ElevatedButton(
-                onPressed: _selectedSchedule == null
-                    ? null // 予定未選択時は null を渡してボタンを無効化
+                onPressed: _selectedTitle == null 
+                    ? null // 未選択の場合はボタン無効
                     : () async {
+                        String targetTitle = "予定なし";
+                        Duration targetDuration = Duration.zero;
+
+                        // 選択された予定がある場合は、そのタイトルと時間を渡す
+                        if (_selectedTitle != "__NO_SCHEDULE__" && currentSchedule != null) {
+                          targetTitle = currentSchedule!.title;
+                          targetDuration = currentSchedule!.duration;
+                        }
+
                         // 計測画面へ遷移
                         final result = await Navigator.push<Duration>(
                           context,
                           MaterialPageRoute(
                             builder: (context) => MeasurementPage(
-                              selectedTitle: _selectedSchedule!.title,
-                              duration: _selectedSchedule!.duration,
+                              selectedTitle: targetTitle,
+                              duration: targetDuration,
                             ),
                           ),
                         );
 
-                        // 5. 計測が完了し、結果が返ってきたら履歴に保存する
+                        // 計測が完了し、結果が返ってきたら履歴に保存する
                         if (result != null) {
-                          // 保存されているリストから、計測した予定を探す
-                          final index = _schedules.indexWhere((s) => s.title == _selectedSchedule!.title);
+                          int index = _schedules.indexWhere((s) => s.title == targetTitle);
+                          
                           if (index != -1) {
+                            // 既存の予定に履歴を追加
                             final schedule = _schedules[index];
                             final his = List<MeasurementHistory>.from(schedule.histories)
                               ..add(MeasurementHistory(
@@ -240,23 +254,57 @@ class _MyHomePageState extends State<MyHomePage> {
                               ));
                             
                             setState(() {
-                              // 新しい履歴を持った予定に上書き
                               _schedules[index] = schedule.copyWith(histories: his);
-                              _selectedSchedule = _schedules[index];
                             });
-                            // ローカルへ保存
-                            await _saveSchedules(_schedules);
+                          } else {
+                            // 「予定なし」で計測した場合は、新しく「予定なし」というスケジュール枠を作って保存
+                            final newSchedule = Schedule(
+                              title: targetTitle,
+                              duration: targetDuration,
+                              histories: [
+                                MeasurementHistory(
+                                  target: targetDuration,
+                                  actual: result,
+                                  timestamp: DateTime.now(),
+                                )
+                              ]
+                            );
+                            setState(() {
+                              _schedules.add(newSchedule);
+                            });
                           }
+                          // ローカルへ保存
+                          await _saveSchedules(_schedules);
                         }
                       },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.blue[100],
                   padding: const EdgeInsets.symmetric(horizontal: 50, vertical: 15),
-                  disabledBackgroundColor: Colors.grey[300], // 無効時の色
+                  disabledBackgroundColor: Colors.grey[300],
                 ),
                 child: const Text('スタート', style: TextStyle(fontSize: 28, color: Colors.black)),
               ),
-              
+              const SizedBox(height: 10),
+
+              // ==========================================
+              // 【追加】履歴を表示ボタン
+              // ==========================================
+              TextButton(
+                onPressed: () {
+                  // measurement_start_screen（一覧画面）へ遷移
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const MeasurementStartScreen(),
+                    ),
+                  ).then((_) => _loadSchedules()); // 戻ってきたら最新状態に更新
+                },
+                child: const Text(
+                  '履歴を表示', 
+                  style: TextStyle(fontSize: 18, color: Colors.deepOrange, decoration: TextDecoration.underline)
+                ),
+              ),
+
               const SizedBox(height: 50),
               const Divider(thickness: 2),
               const Text('--- 以下、既存のテスト用ボタン群 ---', style: TextStyle(color: Colors.grey)),
@@ -276,7 +324,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => ShowHistoryPage(
+                      builder: (context) => const ShowHistoryPage(
                           title: "show history page",
                           targetDuration: Duration(minutes: 10),
                           histories: [],
@@ -304,9 +352,9 @@ class _MyHomePageState extends State<MyHomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => MeasurementStartScreen(),
+                      builder: (context) => const MeasurementStartScreen(),
                     ),
-                  ).then((_) => _loadSchedules()); // 戻ってきた時に予定リストを最新にするための追加
+                  ).then((_) => _loadSchedules());
                 },
                 child: const Text('Go to measurement_start_screen'),
               ),
@@ -316,9 +364,9 @@ class _MyHomePageState extends State<MyHomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => ScheduleCreationScreen(),
+                      builder: (context) => const ScheduleCreationScreen(),
                     ),
-                  ).then((_) => _loadSchedules()); // 戻ってきた時に予定リストを最新にするための追加
+                  ).then((_) => _loadSchedules());
                 },
                 child: const Text('Go to schedule_creation_screen'),
               ),
@@ -328,7 +376,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => MeasurementPage(
+                      builder: (context) => const MeasurementPage(
                         selectedTitle: "テスト用予定名",
                         duration: Duration(minutes: 90), 
                       ),


### PR DESCRIPTION
## 📚 関連Issue
<!-- 関連するIssue番号を記述してください -->
close #(issue番号)

## 📝 概要
<!-- このプルリクエストの概要を簡潔に説明してください -->
プルダウンの選択肢の先頭に「＋ 新規予定作成」と「予定を選択せず開始」を追加しました。また、「履歴を表示」ボタンを追加しました。

<!-- 機能・バグは，やったことに応じて記述してください -->
### 追加した機能
- [ ] 新機能の説明
- [ ] プルダウンの選択肢の先頭に「＋ 新規予定作成」と「予定を選択せず開始」を追加しました。
- [ ] 「＋ 新規予定作成」を選ぶと、即座にスケジュール作成画面に飛びます。作成して戻ってくると、その予定が自動的に選択されます。
- [ ] 「予定を選択せず開始」を選ぶと目標時間が「00:00」になります。スタートして計測を終えると、「予定なし」という名前のスケジュールが自動的に裏で作られ、そこに計測履歴が紐づいて保存されます。
- [ ] 「履歴を表示」ボタンの追加:スタートボタンのすぐ下にオレンジ色で追加しました。これを押すと、すでにある measurement_start_screen.dart（過去の予定一覧と時計マークがある画面）に遷移します。

### 修正したバグ
- [ ] バグの説明

### その他の変更
- [ ] その他の変更内容

## 🔧 技術的な変更
<!-- 技術的な変更があれば記述してください -->
- データベーススキーマの変更
- APIエンドポイントの追加/変更
- 依存関係の更新
- その他

## 🔍 レビュアーへの注意事項
<!-- レビュアーに特に確認してほしい点があれば記述してください -->

## 📝 その他
<!-- その他、補足情報があれば記述してください -->
